### PR TITLE
Add Python finance tutorials outline

### DIFF
--- a/content/python_finance_tutorials.md
+++ b/content/python_finance_tutorials.md
@@ -1,0 +1,154 @@
+# Python for Finance Analysts: Tutorial Overview
+
+This document outlines a complete 30-lesson plan for financial analysts to learn Python. Each lesson lists the context, sample examples, and main concepts to be covered. These topics can be converted into Jupyter notebooks for hands-on practice.
+
+01 - Introduction to Python:
+- Overview of Python's role in financial analysis and why it's widely used.
+- Demonstrate simple scripts that print text and perform calculations.
+- Concepts: syntax basics, the Python interpreter, using Jupyter notebooks.
+
+02 - Installing Python and Setting Up Your Environment:
+- Guide learners through installing Python, Jupyter, and essential packages.
+- Provide example configuration using virtual environments.
+- Concepts: package managers (pip), virtualenv, navigating the command line.
+
+03 - Data Types and Variables:
+- Explain numeric, string, and boolean types in a financial context.
+- Use examples like storing stock tickers and prices as variables.
+- Concepts: variable assignment, type conversion, best practices for naming variables.
+
+04 - Basic Arithmetic and Logical Operations:
+- Show how to perform calculations such as returns and percentage changes.
+- Include simple comparisons to check performance or thresholds.
+- Concepts: arithmetic operators, comparison operators, boolean logic.
+
+05 - Working with Lists and Tuples:
+- Cover creating sequences to store historical prices or transaction records.
+- Provide examples of indexing and slicing to retrieve data.
+- Concepts: mutability, iterating over lists, using tuples for fixed data.
+
+06 - Dictionaries and Sets in Finance:
+- Use dictionaries to map tickers to data and sets to deduplicate symbols.
+- Include examples building a small lookup table for company info.
+- Concepts: key-value pairs, set operations, dictionary methods.
+
+07 - String Manipulation:
+- Focus on parsing financial statements or CSV headers.
+- Provide examples of formatting strings and cleaning text.
+- Concepts: f-strings, common string methods, joining and splitting text.
+
+08 - Working with Dates and Times:
+- Demonstrate handling trade dates and timestamps.
+- Include examples using time zones and calculating date ranges.
+- Concepts: `datetime` module, formatting dates, timedelta arithmetic.
+
+09 - Control Flow: if, else, and loops:
+- Show how conditional logic automates decisions like trade triggers.
+- Use loops to iterate over price series or portfolios.
+- Concepts: `if` statements, `for` and `while` loops, nested conditions.
+
+10 - Functions and Scope:
+- Teach how to modularize code for pricing calculations.
+- Provide examples of reusable helper functions.
+- Concepts: function definitions, parameters, return values, local vs global scope.
+
+11 - Comprehensions and Lambda Functions:
+- Demonstrate list comprehensions to transform datasets concisely.
+- Show lambda expressions for quick computations.
+- Concepts: list, dict, and set comprehensions; anonymous functions.
+
+12 - Error Handling and Debugging:
+- Explain common pitfalls in financial scripts and how to avoid them.
+- Include try/except examples around data loading or API calls.
+- Concepts: exceptions, debugging with print statements or IDE tools.
+
+13 - Introduction to NumPy:
+- Use arrays to store and manipulate large numerical datasets efficiently.
+- Show examples calculating log returns and vectorized operations.
+- Concepts: creating arrays, broadcasting, array methods.
+
+14 - Pandas Basics:
+- Introduce DataFrame structures for tabular financial data.
+- Provide examples loading CSV files with price history.
+- Concepts: Series and DataFrame, indexing, basic data wrangling.
+
+15 - Data Cleaning:
+- Guide through handling missing prices and inconsistent formats.
+- Include examples filling gaps or removing bad records.
+- Concepts: detecting NaNs, filtering data, using `pandas` cleaning methods.
+
+16 - Data Visualization with Matplotlib:
+- Show how to plot line charts of asset prices and bar charts of volumes.
+- Provide tips for customizing visuals for reports.
+- Concepts: basic plotting functions, labels, legends, and styling.
+
+17 - Working with External Data (CSV, Excel, Databases):
+- Explain importing data from spreadsheets or SQL databases.
+- Include examples of reading and writing to files.
+- Concepts: `pandas.read_csv`, Excel helpers, database connectors like SQLite.
+
+18 - Time Series Analysis:
+- Focus on resampling, rolling statistics, and seasonal trends.
+- Show examples analyzing daily versus monthly data.
+- Concepts: DateTime index, resample, rolling window operations.
+
+19 - Financial Metrics:
+- Calculate returns, volatility, Sharpe ratio, and other key indicators.
+- Use sample portfolios to demonstrate real calculations.
+- Concepts: simple and logarithmic returns, risk measures, aggregations.
+
+20 - Portfolio Optimization:
+- Introduce the theory of efficient portfolios and risk/return trade-offs.
+- Provide a small example using optimization libraries.
+- Concepts: mean-variance optimization, constraints, using `scipy.optimize`.
+
+21 - Simple Backtest:
+- Walk through implementing a basic trading strategy backtest.
+- Show how to evaluate performance metrics over time.
+- Concepts: historical simulation, trade signals, equity curve plotting.
+
+22 - Monte Carlo Simulation:
+- Demonstrate simulating price paths and portfolio outcomes.
+- Include examples for option pricing and risk analysis.
+- Concepts: random number generation, scenario analysis, repeating simulations.
+
+23 - Regression Analysis with Statsmodels and Scikit-Learn:
+- Apply linear regression to model relationships like factor exposure.
+- Provide examples of predicting asset returns.
+- Concepts: fitting models, interpreting coefficients, train/test split.
+
+24 - Web Scraping Financial Data:
+- Explain how to pull data from websites when APIs are unavailable.
+- Show basic HTML parsing and data extraction.
+- Concepts: requests, BeautifulSoup, ethical scraping considerations.
+
+25 - Introduction to Financial Data APIs:
+- Demonstrate fetching market data from services like Alpha Vantage or Yahoo Finance.
+- Include authentication and rate-limit handling tips.
+- Concepts: REST API requests, parsing JSON, environment variables for keys.
+
+26 - Automating Reports with Python:
+- Show how to generate PDF or HTML reports summarizing analysis.
+- Provide examples scheduling scripts for end-of-day reporting.
+- Concepts: templating with Jinja2, report generation libraries, cron basics.
+
+27 - Using Python for Excel:
+- Describe automating Excel tasks common in financial workflows.
+- Include examples using openpyxl or xlsxwriter to read and write sheets.
+- Concepts: cell manipulation, formulas, formatting spreadsheets.
+
+28 - Risk Management and Value at Risk (VaR):
+- Teach methods to quantify portfolio risk and potential losses.
+- Provide examples calculating historical and parametric VaR.
+- Concepts: distribution assumptions, confidence intervals, stress testing.
+
+29 - Building a Financial Dashboard with Plotly or Dash:
+- Show how interactive dashboards can visualize key metrics in real time.
+- Include examples deploying locally for stakeholders.
+- Concepts: Plotly basics, Dash layouts, callbacks for interactivity.
+
+30 - Machine Learning Applications in Finance:
+- Explore classification and clustering for credit scoring or anomaly detection.
+- Provide examples using scikit-learn pipelines on financial data.
+- Concepts: feature engineering, model evaluation, considerations for overfitting.
+


### PR DESCRIPTION
## Summary
- add a markdown outline of 30 Python tutorials for financial analysts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68462b65c4688320bb809c5db77a9e73