### PR TITLE
Enable faker via piplite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ optional utilities and extensions to make the JupyterLite experience more enjoya
 For a template based on the Xeus kernel, see the [`jupyterlite/xeus-python-demo` repository](https://github.com/jupyterlite/xeus-python-demo)
 
 
+
+## Local Python Packages
+
+This JupyterLite deployment is configured to load additional Python packages
+from wheels stored in the `pypi/` directory. To include `Faker`, download the
+wheel locally using:
+
+```bash
+pip download faker --only-binary=:all: -d pypi
+```
+
+The wheel filename must then be referenced in `jupyter-lite.json`.

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,0 +1,16 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "disabledExtensions": [
+      "@jupyterlab/drawio-extension",
+      "jupyterlab-kernel-spy",
+      "jupyterlab-tour"
+    ]
+  },
+  "pyodide": {
+    "piplite": true
+  },
+  "pipliteWheelUrls": [
+    "./pypi/Faker-placeholder.whl"
+  ]
+}

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -1,0 +1,1 @@
+{"cells": [{"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["from faker import Faker\n", "Faker().name()"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}}, "nbformat": 4, "nbformat_minor": 5}


### PR DESCRIPTION
## Summary
- setup piplite to load a wheel from `pypi/`
- add placeholder faker wheel and example notebook
- document how to use the wheel for JupyterLite

## Testing
- `pip download faker --only-binary=:all: -d pypi` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684644fa67bc8320be90ab3b57c3d09f