### PR TITLE
Update finance tutorials for corporate use cases

### DIFF
--- a/content/python_finance_tutorials.md
+++ b/content/python_finance_tutorials.md
@@ -1,154 +1,243 @@
 # Python for Finance Analysts: Tutorial Overview
 
-This document outlines a complete 30-lesson plan for financial analysts to learn Python. Each lesson lists the context, sample examples, and main concepts to be covered. These topics can be converted into Jupyter notebooks for hands-on practice.
+This 30-lesson curriculum introduces Python through a series of corporate finance examples. All exercises draw on the synthetic dataset produced by `content/python4finance/generate_ecommerce_dataset.py`, which creates orders, order items, and product tables for an e‑commerce business. In each lesson, concepts are paired with code instructions that reference this dataset.
 
 01 - Introduction to Python:
-- Overview of Python's role in financial analysis and why it's widely used.
-- Demonstrate simple scripts that print text and perform calculations.
+- Overview of Python's role in corporate finance and analytics.
+- Demonstrate simple scripts that print text and calculate basic metrics from the ecommerce dataset.
 - Concepts: syntax basics, the Python interpreter, using Jupyter notebooks.
+- Exercises and examples:
+  1. Run the generator script to create the dataset.
+  2. Load the resulting CSVs into Python and print the number of orders and products.
 
 02 - Installing Python and Setting Up Your Environment:
-- Guide learners through installing Python, Jupyter, and essential packages.
-- Provide example configuration using virtual environments.
+- Guide learners through installing Python, Jupyter, and packages required for working with corporate data.
+- Provide configuration instructions for virtual environments.
 - Concepts: package managers (pip), virtualenv, navigating the command line.
+- Exercises and examples:
+  1. Create a new virtual environment and install pandas, matplotlib, and faker.
+  2. Generate the ecommerce dataset inside the environment and verify the files were written.
 
 03 - Data Types and Variables:
-- Explain numeric, string, and boolean types in a financial context.
-- Use examples like storing stock tickers and prices as variables.
+- Explain numeric, string, and boolean types using transaction amounts and product information.
+- Examples include storing total sales and flags for high-value customers.
 - Concepts: variable assignment, type conversion, best practices for naming variables.
+- Exercises and examples:
+  1. Calculate the total value of all orders from the dataset.
+  2. Create a boolean variable that marks orders above a chosen threshold.
 
 04 - Basic Arithmetic and Logical Operations:
-- Show how to perform calculations such as returns and percentage changes.
-- Include simple comparisons to check performance or thresholds.
+- Perform revenue growth calculations and percent changes across months.
+- Use comparisons to flag unusual purchase amounts.
 - Concepts: arithmetic operators, comparison operators, boolean logic.
+- Exercises and examples:
+  1. Compute month‑over‑month revenue differences.
+  2. Use logical operators to identify orders over a certain dollar amount and placed on a weekend.
 
 05 - Working with Lists and Tuples:
-- Cover creating sequences to store historical prices or transaction records.
-- Provide examples of indexing and slicing to retrieve data.
-- Concepts: mutability, iterating over lists, using tuples for fixed data.
+- Store sequences of customer IDs or locations for further analysis.
+- Index and slice lists to retrieve subsets of transactions.
+- Concepts: mutability, iterating over lists, using tuples for fixed data like payment methods.
+- Exercises and examples:
+  1. Build a list of all unique customer locations from the orders table.
+  2. Iterate over a slice of the list to display the first five locations.
 
 06 - Dictionaries and Sets in Finance:
-- Use dictionaries to map tickers to data and sets to deduplicate symbols.
-- Include examples building a small lookup table for company info.
+- Map product IDs to categories and use sets to deduplicate customer IDs.
+- Create a simple lookup for product prices.
 - Concepts: key-value pairs, set operations, dictionary methods.
+- Exercises and examples:
+  1. Construct a dictionary keyed by ProductID with base prices as values.
+  2. Use a set to find the number of unique customers who placed orders.
 
 07 - String Manipulation:
-- Focus on parsing financial statements or CSV headers.
-- Provide examples of formatting strings and cleaning text.
+- Parse invoice numbers and format descriptions for reports.
+- Examples include cleaning whitespace and constructing formatted output.
 - Concepts: f-strings, common string methods, joining and splitting text.
+- Exercises and examples:
+  1. Format a string showing a customer's total spend with two decimal places.
+  2. Split the PaymentMethod column to separate words and count occurrences.
 
 08 - Working with Dates and Times:
-- Demonstrate handling trade dates and timestamps.
-- Include examples using time zones and calculating date ranges.
+- Handle order dates, calculate durations between orders, and group by month.
+- Demonstrate time zone handling for online sales across regions.
 - Concepts: `datetime` module, formatting dates, timedelta arithmetic.
+- Exercises and examples:
+  1. Convert the OrderDate column to datetime and extract the month.
+  2. Compute the number of days since each customer's previous order.
 
 09 - Control Flow: if, else, and loops:
-- Show how conditional logic automates decisions like trade triggers.
-- Use loops to iterate over price series or portfolios.
+- Automate decisions such as flagging risky transactions or generating alerts.
+- Use loops to iterate through orders and summarize totals by location.
 - Concepts: `if` statements, `for` and `while` loops, nested conditions.
+- Exercises and examples:
+  1. Loop through orders and print a warning for purchases over a limit.
+  2. Create a summary dictionary that accumulates sales by payment method.
 
 10 - Functions and Scope:
-- Teach how to modularize code for pricing calculations.
-- Provide examples of reusable helper functions.
+- Modularize recurring calculations like computing order discounts.
+- Provide examples of reusable helper functions on the ecommerce dataset.
 - Concepts: function definitions, parameters, return values, local vs global scope.
+- Exercises and examples:
+  1. Write a function that calculates a volume discount based on the number of items in an order.
+  2. Use the function to apply discounts to all order items and compute the new totals.
 
-11 - Comprehensions and Lambda Functions:
-- Demonstrate list comprehensions to transform datasets concisely.
-- Show lambda expressions for quick computations.
+11 - Object-Oriented Programming Basics:
+- Introduce classes and objects for organizing corporate finance logic.
+- Demonstrate a `Customer` class that stores orders and methods for total spend.
+- Concepts: defining classes, instance vs class variables, methods, simple inheritance.
+- Exercises and examples:
+  1. Implement a `Product` class with attributes for ID, category, and base price.
+  2. Create instances of the class from the products table and compute the average price by calling a method.
+
+12 - Comprehensions and Lambda Functions:
+- Use list comprehensions to transform datasets succinctly.
+- Show lambda expressions for quick calculations on order items.
 - Concepts: list, dict, and set comprehensions; anonymous functions.
+- Exercises and examples:
+  1. Build a list of all purchase amounts using a list comprehension.
+  2. Use a lambda with `apply` to categorize orders as small or large purchases.
 
-12 - Error Handling and Debugging:
-- Explain common pitfalls in financial scripts and how to avoid them.
-- Include try/except examples around data loading or API calls.
+13 - Error Handling and Debugging:
+- Explain common pitfalls when processing financial data and how to catch them.
+- Include try/except blocks around file loading and calculations.
 - Concepts: exceptions, debugging with print statements or IDE tools.
+- Exercises and examples:
+  1. Attempt to load a missing file and handle the resulting exception gracefully.
+  2. Use assertions to validate that no purchase amounts are negative.
 
-13 - Introduction to NumPy:
-- Use arrays to store and manipulate large numerical datasets efficiently.
-- Show examples calculating log returns and vectorized operations.
+14 - Introduction to NumPy:
+- Store large numeric arrays of sales quantities and perform vectorized math.
+- Examples include computing log growth rates across many months.
 - Concepts: creating arrays, broadcasting, array methods.
+- Exercises and examples:
+  1. Convert the purchase amounts to a NumPy array and calculate descriptive statistics.
+  2. Demonstrate broadcasting by applying a tax rate to all purchase amounts.
 
-14 - Pandas Basics:
-- Introduce DataFrame structures for tabular financial data.
-- Provide examples loading CSV files with price history.
-- Concepts: Series and DataFrame, indexing, basic data wrangling.
+15 - Pandas Basics:
+- Introduce DataFrames for handling the ecommerce orders, items, and products tables.
+- Examples cover loading the generated dataset and exploring columns.
+- Concepts: Series and DataFrame, indexing, merging tables, basic data wrangling.
+- Exercises and examples:
+  1. Merge orders with order items to create a single analysis DataFrame.
+  2. Select orders from a specific location and compute the total revenue for that location.
 
-15 - Data Cleaning:
-- Guide through handling missing prices and inconsistent formats.
-- Include examples filling gaps or removing bad records.
+16 - Data Cleaning:
+- Handle missing values and inconsistent formats in the ecommerce data.
+- Use techniques such as filling gaps and removing outliers.
 - Concepts: detecting NaNs, filtering data, using `pandas` cleaning methods.
+- Exercises and examples:
+  1. Identify orders with missing customer locations and fill them with "Unknown".
+  2. Remove outlier purchase amounts using the interquartile range method.
 
-16 - Data Visualization with Matplotlib:
-- Show how to plot line charts of asset prices and bar charts of volumes.
-- Provide tips for customizing visuals for reports.
-- Concepts: basic plotting functions, labels, legends, and styling.
+17 - Data Visualization with Matplotlib and Seaborn:
+- Plot revenue trends, product category breakdowns, and customer distribution.
+- Provide tips for customizing visuals for board presentations.
+- Concepts: line and bar charts, histograms, style settings, legends, and labels.
+- Exercises and examples:
+  1. Create a monthly revenue line chart from the orders table.
+  2. Plot a bar chart showing the number of orders by payment method using Seaborn.
 
-17 - Working with External Data (CSV, Excel, Databases):
-- Explain importing data from spreadsheets or SQL databases.
-- Include examples of reading and writing to files.
-- Concepts: `pandas.read_csv`, Excel helpers, database connectors like SQLite.
+18 - Working with External Data (CSV, Excel, Databases):
+- Import supplemental corporate data such as budgets or HR costs.
+- Demonstrate reading from and writing to CSV and Excel files alongside the ecommerce dataset.
+- Concepts: `pandas.read_csv`, Excel helpers, and basic database connectors like SQLite.
+- Exercises and examples:
+  1. Save aggregated revenue by product category to an Excel file.
+  2. Load a separate CSV of marketing spend and merge it with order totals.
 
-18 - Time Series Analysis:
-- Focus on resampling, rolling statistics, and seasonal trends.
-- Show examples analyzing daily versus monthly data.
+19 - Time Series Analysis:
+- Resample daily sales data to monthly and analyze seasonality.
+- Calculate rolling averages to smooth revenue trends.
 - Concepts: DateTime index, resample, rolling window operations.
+- Exercises and examples:
+  1. Resample the order data by month and compute average order value.
+  2. Plot a 30‑day rolling mean of daily sales to visualize trends.
 
-19 - Financial Metrics:
-- Calculate returns, volatility, Sharpe ratio, and other key indicators.
-- Use sample portfolios to demonstrate real calculations.
-- Concepts: simple and logarithmic returns, risk measures, aggregations.
+20 - Corporate Financial Metrics:
+- Compute metrics such as gross margin, contribution margin, and cash conversion cycle.
+- Use the ecommerce dataset to illustrate each calculation.
+- Concepts: revenue, cost of goods sold, receivables and payables timing.
+- Exercises and examples:
+  1. Estimate gross margin by subtracting base price from purchase amounts.
+  2. Derive days sales outstanding using simulated payment dates.
 
-20 - Portfolio Optimization:
-- Introduce the theory of efficient portfolios and risk/return trade-offs.
-- Provide a small example using optimization libraries.
-- Concepts: mean-variance optimization, constraints, using `scipy.optimize`.
+21 - Capital Allocation Optimization:
+- Introduce optimization methods for budgeting and resource allocation.
+- Provide a small example using `scipy.optimize` to allocate marketing spend across channels.
+- Concepts: objective functions, constraints, interpreting optimization results.
+- Exercises and examples:
+  1. Define a cost function that maximizes projected revenue for different budget allocations.
+  2. Use `scipy.optimize.minimize` to find the best allocation under a fixed budget.
 
-21 - Simple Backtest:
-- Walk through implementing a basic trading strategy backtest.
-- Show how to evaluate performance metrics over time.
-- Concepts: historical simulation, trade signals, equity curve plotting.
+22 - Scenario Analysis and Forecasting:
+- Walk through creating scenarios for revenue forecasts based on varying assumptions.
+- Show how to evaluate outcomes using simple loops and data transformations.
+- Concepts: scenario generation, sensitivity testing, summary statistics.
+- Exercises and examples:
+  1. Create optimistic, base, and pessimistic growth scenarios for monthly revenue.
+  2. Compute the effect on annual revenue under each scenario.
 
-22 - Monte Carlo Simulation:
-- Demonstrate simulating price paths and portfolio outcomes.
-- Include examples for option pricing and risk analysis.
-- Concepts: random number generation, scenario analysis, repeating simulations.
+23 - Monte Carlo Simulation:
+- Demonstrate simulating sales outcomes to model uncertainty.
+- Include examples for cash-flow forecasting and risk analysis.
+- Concepts: random number generation, repeated simulations, analyzing distributions.
+- Exercises and examples:
+  1. Simulate thousands of revenue paths assuming random monthly growth rates.
+  2. Plot the distribution of simulated yearly revenue totals.
 
-23 - Regression Analysis with Statsmodels and Scikit-Learn:
-- Apply linear regression to model relationships like factor exposure.
-- Provide examples of predicting asset returns.
+24 - Regression Analysis with Statsmodels and Scikit-Learn:
+- Apply linear regression to model relationships like advertising spend versus sales.
+- Provide examples predicting revenue from marketing and seasonal variables.
 - Concepts: fitting models, interpreting coefficients, train/test split.
+- Exercises and examples:
+  1. Fit a linear model using product category dummy variables to predict purchase amounts.
+  2. Evaluate the model using out-of-sample test data.
 
-24 - Web Scraping Financial Data:
-- Explain how to pull data from websites when APIs are unavailable.
-- Show basic HTML parsing and data extraction.
-- Concepts: requests, BeautifulSoup, ethical scraping considerations.
-
-25 - Introduction to Financial Data APIs:
-- Demonstrate fetching market data from services like Alpha Vantage or Yahoo Finance.
-- Include authentication and rate-limit handling tips.
-- Concepts: REST API requests, parsing JSON, environment variables for keys.
+25 - Web Scraping and Data APIs:
+- Pull supplemental economic data or competitor pricing information.
+- Show basic HTML parsing and API requests.
+- Concepts: requests library, BeautifulSoup, ethical scraping considerations.
+- Exercises and examples:
+  1. Retrieve currency exchange rates from a public API and merge them with the orders data.
+  2. Scrape product prices from a sample website and compare them to internal pricing.
 
 26 - Automating Reports with Python:
-- Show how to generate PDF or HTML reports summarizing analysis.
-- Provide examples scheduling scripts for end-of-day reporting.
+- Generate PDF or HTML reports summarizing revenue and key metrics.
+- Examples include scheduling weekly report generation.
 - Concepts: templating with Jinja2, report generation libraries, cron basics.
+- Exercises and examples:
+  1. Create an HTML report that includes charts generated in earlier lessons.
+  2. Schedule the report script to run automatically using a cron job.
 
 27 - Using Python for Excel:
-- Describe automating Excel tasks common in financial workflows.
-- Include examples using openpyxl or xlsxwriter to read and write sheets.
+- Automate Excel tasks common in corporate workflows.
+- Examples use openpyxl or xlsxwriter to update management spreadsheets.
 - Concepts: cell manipulation, formulas, formatting spreadsheets.
+- Exercises and examples:
+  1. Write the monthly revenue summary to an Excel workbook with formatting.
+  2. Insert a chart object showing product category sales into a worksheet.
 
-28 - Risk Management and Value at Risk (VaR):
-- Teach methods to quantify portfolio risk and potential losses.
-- Provide examples calculating historical and parametric VaR.
+28 - Risk Management and Sensitivity Testing:
+- Teach methods to quantify financial risk and potential losses in a corporate context.
+- Provide examples calculating value at risk on projected sales.
 - Concepts: distribution assumptions, confidence intervals, stress testing.
+- Exercises and examples:
+  1. Use historical revenue volatility to estimate value at risk.
+  2. Stress test a sharp drop in demand and quantify the revenue impact.
 
-29 - Building a Financial Dashboard with Plotly or Dash:
-- Show how interactive dashboards can visualize key metrics in real time.
+29 - Building a Corporate Dashboard with Plotly or Dash:
+- Show how interactive dashboards visualize KPIs in real time.
 - Include examples deploying locally for stakeholders.
 - Concepts: Plotly basics, Dash layouts, callbacks for interactivity.
+- Exercises and examples:
+  1. Create an interactive dashboard showing revenue by region and payment method.
+  2. Add filters that allow users to view metrics for selected product categories.
 
-30 - Machine Learning Applications in Finance:
-- Explore classification and clustering for credit scoring or anomaly detection.
-- Provide examples using scikit-learn pipelines on financial data.
+30 - Machine Learning Applications in Corporate Finance:
+- Explore classification and clustering for customer segmentation or anomaly detection.
+- Provide examples using scikit-learn pipelines on the ecommerce dataset.
 - Concepts: feature engineering, model evaluation, considerations for overfitting.
-
+- Exercises and examples:
+  1. Cluster customers based on order history to identify high-value segments.
+  2. Train a classification model to flag potentially fraudulent orders.


### PR DESCRIPTION
## Summary
- refocus tutorial on corporate finance and ecommerce data
- describe detailed code exercises for each lesson
- add object-oriented programming overview
- expand pandas and visualization sections

## Testing
- `python -m py_compile content/python4finance/generate_ecommerce_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6846c20f71688320bac9b20284def11b